### PR TITLE
Allow tests to be skipped even when class initialization fails

### DIFF
--- a/test/TestISpecification.cs
+++ b/test/TestISpecification.cs
@@ -94,15 +94,11 @@ namespace Xunit.Bdd.Test
 
 		[Observation]
 		public void should_fail()
-		{
-			// This test will have an inconclusive result because of the exception thrown in Observe()
-		}
+		{ }
 
-		[Observation(Skip = "YOU SHOULD NEVER SEE THIS AS A TEST RESULT")] // The runner can't reach the point where it skips a test if its setup can't be run first.
-		public void should_still_fail_even_if_skipped()
-		{
-			// This test will have an inconclusive result because of the exception thrown in Observe()
-		}
+		[Observation(Skip = "This test should never fail")]
+		public void should_skip_even_if_constructor_throws()
+		{ }
 	}
 
 	public class behaves_like_an_ispecification_that_unexpectedly_throws_during_construction : ISpecification
@@ -120,8 +116,8 @@ namespace Xunit.Bdd.Test
 		public void should_fail()
 		{ }
 
-		[Observation(Skip = "YOU SHOULD NEVER SEE THIS MESSAGE")] // The runner can't reach the point where it skips a test if its setup can't be run first.
-		public void should_still_fail_even_if_skipped()
+		[Observation(Skip = "This test should never fail")]
+		public void should_skip_even_if_constructor_throws()
 		{ }
 	}
 }

--- a/test/TestSpecification.cs
+++ b/test/TestSpecification.cs
@@ -90,8 +90,8 @@ namespace Xunit.Bdd.Test
 		public void should_fail()
 		{ }
 
-		[Observation(Skip = "YOU SHOULD NEVER SEE THIS MESSAGE")] // The runner can't reach the point where it skips a test if its setup can't be run first.
-		public void should_still_fail_even_if_skipped()
+		[Observation(Skip = "This test should never fail")]
+		public void should_skip_even_if_Observe_throws()
 		{ }
 	}
 
@@ -135,8 +135,8 @@ namespace Xunit.Bdd.Test
 		public void should_fail()
 		{ }
 
-		[Observation(Skip = "YOU SHOULD NEVER SEE THIS MESSAGE")] // The runner can't reach the point where it skips a test if its setup can't be run first.
-		public void should_still_fail_even_if_skipped()
+		[Observation(Skip = "This test should never fail")]
+		public void should_skip_even_if_constructor_throws()
 		{ }
 	}
 }


### PR DESCRIPTION
Assigning to the `Skip` property on `[ObservationAttribute]` now makes that test correctly present as "Skipped", even if class construction or the `Observe()` call threw an exception.